### PR TITLE
Clean out promises as soon as complete

### DIFF
--- a/file.js
+++ b/file.js
@@ -46,6 +46,12 @@ const ensureDirectory = function ( directory ) {
 			} );
 		} );
 	} );
+
+	// Clear cache after complete.
+	ensuring[ directory ].finally( () => {
+		delete ensuring[ directory ];
+	} );
+
 	return ensuring[ directory ];
 };
 


### PR DESCRIPTION
This ensures we only reuse promises to prevent concurrency issues, rather than caching permanently. Allows reusing the container better, and allows us to wipe out the tmp directories after we're done with  them.

See https://github.com/humanmade/linter-bot/pull/91