### PR TITLE
Add PDF to ignored file types in extracting

### DIFF
--- a/repo.js
+++ b/repo.js
@@ -29,7 +29,7 @@ const download = async ( extractDir, pushConfig, github ) => {
 		cwd:   extractDir,
 		file:  tarball,
 		strip: 1,
-		filter: path => ! path.match( /\.(jpg|jpeg|png|gif|woff|swf|flv|fla|woff|svg|otf||ttf|eot|swc|xap)$/ ),
+		filter: path => ! path.match( /\.(jpg|jpeg|png|gif|woff|swf|flv|fla|woff|svg|otf||ttf|eot|swc|xap|pdf)$/ ),
 	} );
 	console.log( 'Completed extraction.' );
 


### PR DESCRIPTION
The git repo can have a lot of PDFs which takes a lot of room, and are highly unlikely to be needed